### PR TITLE
Fixes in password-validator Makefile commands

### DIFF
--- a/password-validator/Makefile
+++ b/password-validator/Makefile
@@ -6,7 +6,7 @@ dependencies:
 	composer install
 .PHONY: tests
 tests:
-	./vendor/bin/phpunit
+	@docker run --rm -v $(shell pwd):/opt/project php-docker-bootstrap vendor/bin/phpunit
 .PHONY: coverage
 coverage:
 	./vendor/bin/phpunit --coverage-html coverage

--- a/password-validator/Makefile
+++ b/password-validator/Makefile
@@ -11,7 +11,7 @@ tests:
 coverage:
 	@docker run --rm -v $(shell pwd):/opt/project php-docker-bootstrap vendor/bin/phpunit --coverage-html coverage
 mutants:
-	./vendor/bin/infection
+	@docker run --rm -v $(shell pwd):/opt/project php-docker-bootstrap vendor/bin/infection
 
 # Docker commands
 docker-build:

--- a/password-validator/Makefile
+++ b/password-validator/Makefile
@@ -9,7 +9,7 @@ tests:
 	@docker run --rm -v $(shell pwd):/opt/project php-docker-bootstrap vendor/bin/phpunit
 .PHONY: coverage
 coverage:
-	./vendor/bin/phpunit --coverage-html coverage
+	@docker run --rm -v $(shell pwd):/opt/project php-docker-bootstrap vendor/bin/phpunit --coverage-html coverage
 mutants:
 	./vendor/bin/infection
 

--- a/password-validator/Makefile
+++ b/password-validator/Makefile
@@ -16,14 +16,14 @@ mutants:
 # Docker commands
 docker-build:
 	docker build -t php-docker-bootstrap .
-	@docker run -v $(shell pwd):/opt/project php-docker-bootstrap make dependencies
+	@docker run --rm -v $(shell pwd):/opt/project php-docker-bootstrap make dependencies
 
 docker-tests:
-	@docker run -v $(shell pwd):/opt/project php-docker-bootstrap make tests
+	@docker run --rm -v $(shell pwd):/opt/project php-docker-bootstrap make tests
 docker-coverage:
-	@docker run -v $(shell pwd):/opt/project php-docker-bootstrap make coverage
+	@docker run --rm -v $(shell pwd):/opt/project php-docker-bootstrap make coverage
 docker-mutants:
-	@docker run -v $(shell pwd):/opt/project php-docker-bootstrap phpdbg -qrr ./vendor/bin/infection
+	@docker run --rm -v $(shell pwd):/opt/project php-docker-bootstrap phpdbg -qrr ./vendor/bin/infection
 
 define HELP
 # Local commands


### PR DESCRIPTION
Hola Luís, he tenido algunos fallos al iniciar la kata `password-validator` al no estar usándose docker en algunos comandos. También he actualizado todos los `docker run` con el flag `--rm` para no dejar contenedores muertos.

Hi Luís, I had some issues initializing `password-validator` due to some commands that were executing without docker. I also have updated all `docker run` commands to be flagged with `--rm` to avoid iddle docker containers.